### PR TITLE
Expose timestamps option

### DIFF
--- a/cmd/graphite_exporter/main.go
+++ b/cmd/graphite_exporter/main.go
@@ -36,15 +36,16 @@ import (
 )
 
 var (
-	listenAddress   = kingpin.Flag("web.listen-address", "Address on which to expose metrics.").Default(":9108").String()
-	metricsPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
-	graphiteAddress = kingpin.Flag("graphite.listen-address", "TCP and UDP address on which to accept samples.").Default(":9109").String()
-	mappingConfig   = kingpin.Flag("graphite.mapping-config", "Metric mapping configuration file name.").Default("").String()
-	sampleExpiry    = kingpin.Flag("graphite.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
-	strictMatch     = kingpin.Flag("graphite.mapping-strict-match", "Only store metrics that match the mapping configuration.").Bool()
-	cacheSize       = kingpin.Flag("graphite.cache-size", "Maximum size of your metric mapping cache. Relies on least recently used replacement policy if max size is reached.").Default("1000").Int()
-	cacheType       = kingpin.Flag("graphite.cache-type", "Metric mapping cache type. Valid options are \"lru\" and \"random\"").Default("lru").Enum("lru", "random")
-	dumpFSMPath     = kingpin.Flag("debug.dump-fsm", "The path to dump internal FSM generated for glob matching as Dot file.").Default("").String()
+	listenAddress    = kingpin.Flag("web.listen-address", "Address on which to expose metrics.").Default(":9108").String()
+	metricsPath      = kingpin.Flag("web.telemetry-path", "Path under which to expose Prometheus metrics.").Default("/metrics").String()
+	exposeTimestamps = kingpin.Flag("web.expose-timestamps", "Expose timestamps from Graphite samples").Default("false").Bool()
+	graphiteAddress  = kingpin.Flag("graphite.listen-address", "TCP and UDP address on which to accept samples.").Default(":9109").String()
+	mappingConfig    = kingpin.Flag("graphite.mapping-config", "Metric mapping configuration file name.").Default("").String()
+	sampleExpiry     = kingpin.Flag("graphite.sample-expiry", "How long a sample is valid for.").Default("5m").Duration()
+	strictMatch      = kingpin.Flag("graphite.mapping-strict-match", "Only store metrics that match the mapping configuration.").Bool()
+	cacheSize        = kingpin.Flag("graphite.cache-size", "Maximum size of your metric mapping cache. Relies on least recently used replacement policy if max size is reached.").Default("1000").Int()
+	cacheType        = kingpin.Flag("graphite.cache-type", "Metric mapping cache type. Valid options are \"lru\" and \"random\"").Default("lru").Enum("lru", "random")
+	dumpFSMPath      = kingpin.Flag("debug.dump-fsm", "The path to dump internal FSM generated for glob matching as Dot file.").Default("").String()
 )
 
 func init() {
@@ -105,6 +106,7 @@ func main() {
 	}
 
 	c.SetMapper(metricMapper)
+	c.ExposeTimestamps(*exposeTimestamps)
 
 	tcpSock, err := net.Listen("tcp", *graphiteAddress)
 	if err != nil {

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -45,6 +45,7 @@ type graphiteCollector struct {
 	lastProcessed      prometheus.Gauge
 	sampleExpiryMetric prometheus.Gauge
 	sampleExpiry       time.Duration
+	exposeTimestamps   bool
 }
 
 func NewGraphiteCollector(logger log.Logger, strictMatch bool, sampleExpiry time.Duration) *graphiteCollector {
@@ -78,6 +79,10 @@ func NewGraphiteCollector(logger log.Logger, strictMatch bool, sampleExpiry time
 	go c.processSamples()
 	go c.processLines()
 	return c
+}
+
+func (c *graphiteCollector) ExposeTimestamps(exposeTimestamps bool) {
+	c.exposeTimestamps = exposeTimestamps
 }
 
 func (c *graphiteCollector) ProcessReader(reader io.Reader) {
@@ -229,11 +234,16 @@ func (c graphiteCollector) Collect(ch chan<- prometheus.Metric) {
 		if ageLimit.After(sample.Timestamp) {
 			continue
 		}
-		ch <- prometheus.MustNewConstMetric(
+		var metric prometheus.Metric
+		metric = prometheus.MustNewConstMetric(
 			prometheus.NewDesc(sample.Name, sample.Help, []string{}, sample.Labels),
 			sample.Type,
 			sample.Value,
 		)
+		if c.exposeTimestamps {
+			metric = prometheus.NewMetricWithTimestamp(sample.Timestamp, metric)
+		}
+		ch <- metric
 	}
 }
 


### PR DESCRIPTION
Our environment needs a highly scalable Graphite implementation, and Prometheus/Cortex sounds to be a better option than MetricTank and co :) (still have to be tested/proven).
For metrics to make sense (for instance looking at Loki logs within the same time frame than metrics) we really need sample times and not scrape ones.

This is https://github.com/prometheus/graphite_exporter/issues/29.